### PR TITLE
Fix event scraping

### DIFF
--- a/pages/events.js
+++ b/pages/events.js
@@ -59,14 +59,14 @@ function get()
                             var eventType = (eventItemWrapper.classList + "").replace("event-item-wrapper ", "");
                             eventType = eventType.replace("é", "e");
 
-                            var start = eventDates[eventID].start;
-                            var end = eventDates[eventID].end;
+                            var start = eventDates[eventID]?.start || null;
+                            var end = eventDates[eventID]?.end || null;
 
-                            if (start.length > 24)
+                            if (start?.length > 24)
                             {
                                 start = "" + new Date(Date.parse(start)).toISOString();
                             }
-                            if (end.length > 24)
+                            if (end?.length > 24)
                             {
                                 end = "" + new Date(Date.parse(end)).toISOString();
                             }

--- a/pages/events.js
+++ b/pages/events.js
@@ -49,7 +49,7 @@ function get()
                             var image = e.querySelector(":scope > .event-item-wrapper > .event-item > .event-img-wrapper > img").src;
                             if (image.includes("cdn-cgi"))
                             {
-                                image = "https://leekduck.com/assets/" + image.split("/assets/")[1];
+                                image = "https://cdn.leekduck.com/assets/" + image.split("/assets/")[1];
                             }
                             var link = e.href;
                             var eventID = link.split("/events/")[1];


### PR DESCRIPTION
This PR fixes two issues with events scraping.

The first issue causes event scraping to fail when an event is missing from the [LeekDuck Event API](https://leekduck.com/feeds/events.json) but exists on the events [page](https://leekduck.com/events/). The fix defaults the start and end times to null, as documented in the [wiki](https://github.com/bigfoott/ScrapedDuck/wiki/Events#fields). At the time of creating this PR, one such event is gbl-dual-destiny_great-league_holiday-cup-little-edition.

The second fix updates the scraper to use the new LeekDuck CDN for event images, as the old links now result in 404 errors.