### PR TITLE
Added generation of iCal format calendar event files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "bigfoott",
   "license": "MIT",
   "dependencies": {
+    "ical-generator": "^8.0.1",
     "jsdom": "21.1.1",
     "moment": "latest"
   }


### PR DESCRIPTION
Hiya!

So I've been using your nifty little iOS scriptable widget for a bit now and loving it. I realized there was one other place I wanted to be able to see the data you're scraping from LeekDuck: in my calendar!

Rather than asking, I figured I would instead be the change I wanted to see in the world:

This PR adds a function to `combinedetails.js` that generates iCal format `.ics` files for each type of event, plus one "all" that includes each event. The calendar files are created based on their `eventType` as `files/calendars/*.ics`.

The benefit of having the `ics` files published alongside the JSON like this, is that users would be able to subscribe to the URL of the calendar(s) they're interested in, and they would be updated automatically just like anything using the JSON directly.

Cheers and thanks for all your effort! 💖