### PR TITLE
Ensure all timestamps for iCal events in UTC

### DIFF
--- a/combinedetails.js
+++ b/combinedetails.js
@@ -102,10 +102,14 @@ function generateCalendars(events) {
         const calAll = icals.get("all");
         const calType = icals.get(e.eventType);
 
+        // ensure the timestamps are all in zulu time
+        const startZulu = new Date(e.start).toISOString();
+        const endZulu = new Date(e.end).toISOString();
         const calEventTitle = `${e.heading} — ${e.name}`
+
         const calEvent = {
-            start: e.start,
-            end: e.end,
+            start: startZulu,
+            end: endZulu,
             id: `scraped-duck-${e.eventID}`,
             summary: calEventTitle,
             description: `<a href="${e.link}">${e.name}</a>`,


### PR DESCRIPTION
In the classic case of "it worked on my machine", I had erroneously made the [assumption](https://gist.github.com/timvisee/fcda9bbdff88d45cc9061606b4b923ca) that the event timestamps were already in UTC. It looks like that was true, but any of the timestamps that didn't hit the [`Date` constructor](https://github.com/bigfoott/ScrapedDuck/blob/1d3b7868e70b2752354bb3b3c456fef11fce6c93/pages/events.js#L72) weren't marked with the `Z`. This made the iCal generator library assume they're local, and thus generated with incorrect times.

Running each stamp through the date constructor & `toISOString` before passing to the calendar generator should get everything in line as expected!