### PR TITLE
Added isGiftExchange property to eggs

### DIFF
--- a/pages/eggs.js
+++ b/pages/eggs.js
@@ -21,6 +21,7 @@ function get()
                 {
                     currentType = c.innerHTML.trim();
                     currentAdventureSync = currentType.includes("(Adventure Sync Rewards)");
+                    currentGiftExchange = currentType.includes("(From Route Gift)");
                     currentType = currentType.split(" Eggs")[0];
                 }
                 else if (c.className == "egg-list-flex")
@@ -37,7 +38,8 @@ function get()
                                 min: -1,
                                 max: -1
                             },
-                            isRegional: false
+                            isRegional: false,
+                            isGiftExchange: false
                         };
 
                         pokemon.name = e.querySelector(":scope > .hatch-pkmn").innerHTML;
@@ -46,6 +48,7 @@ function get()
                         pokemon.image = e.querySelector(":scope > .egg-list-img > img").src;
                         pokemon.canBeShiny = e.querySelector(":scope > .shiny-icon") != null;
                         pokemon.isRegional = e.querySelector(":scope > .regional-icon") != null;
+                        pokemon.isGiftExchange = currentGiftExchange;
 
                         var combatPower = e.querySelector(":scope > .font-size-smaller").innerHTML.split('</span>')[1];
                         pokemon.combatPower.min = parseInt(combatPower.split(' - ')[0]);


### PR DESCRIPTION
Hello, this PR addresses issue https://github.com/bigfoott/ScrapedDuck/issues/19 by adding a new `isGiftExchange` property to eggs.json and eggs.min.json. This is done using the same method that Adventure Sync eggs are differentiated, by checking the text of the current header.

| New Field | Type | Description |
| - | - | - |
| `isGiftExchange` | `boolean` | Whether or not the egg is obtained from Mateo's Gift Exchange at the end of routes. |