### PR TITLE
Add scraping of promo codes from 'Research' pages

### DIFF
--- a/combinedetails.js
+++ b/combinedetails.js
@@ -55,6 +55,13 @@ function main()
                         }
                         e.extraData.raidbattles = data.data
                     }
+                    else if (data.type == "promo-codes")
+                    {
+                        if (e.extraData === null) {
+                            e.extraData = {};
+                        }
+                        e.extraData.promocodes = data.data
+                    }
                 }
             });
         });

--- a/detailedscrape.js
+++ b/detailedscrape.js
@@ -5,6 +5,7 @@ const breakthrough = require('./pages/detailed/breakthrough')
 const spotlight = require('./pages/detailed/spotlight')
 const communityday = require('./pages/detailed/communityday')
 const raidbattles = require('./pages/detailed/raidbattles')
+const research = require('./pages/detailed/research')
 const generic = require('./pages/detailed/generic')
 
 function main()
@@ -43,6 +44,10 @@ function main()
                     else if (e.eventType == "raid-battles")
                     {
                         raidbattles.get(e.link, e.eventID, bkp);
+                    }
+                    else if (e.eventType == "research")
+                    {
+                        research.get(e.link, e.eventID, bkp);
                     }
                 });
             }

--- a/pages/detailed/research.js
+++ b/pages/detailed/research.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const jsd = require('jsdom');
+const { JSDOM } = jsd;
+const https = require('https');
+ 
+function get(url, id, bkp)
+{
+    return new Promise(resolve => {
+        JSDOM.fromURL(url, {
+        })
+        .then((dom) => {
+
+            // grab all the links from the page
+            var links = Array.from(dom.window.document.querySelectorAll('a'));
+            
+            // look for links to the store 'offer redemption' page, and pluck out the passcodes.
+            var codes = links.map(l => l.href)
+                .filter(href => href.includes('store.pokemongo.com/offer-redemption'))
+                .map(href => {
+                    var captures = /.*?passcode=(\w+)/.exec(href);
+                    if (captures && captures.length > 1) {
+                        return captures[1];
+                    }
+                    return null;
+                })
+                .filter(code => code != null);
+            
+            if (!codes || codes.length == 0) {
+                return;
+            }
+            
+            fs.writeFile(`files/temp/${id}_codes.json`, JSON.stringify({ id: id, type: "promo-codes", data: codes }), err => {
+                if (err) {
+                    console.error(err);
+                    return;
+                }
+            });
+        }).catch(_err =>
+        {
+            console.error(_err);
+        });
+    })
+}
+
+module.exports = { get }


### PR DESCRIPTION
Hey Anthony!

Back again with a tiny feature: this change just adds the ability to scrape promo codes from research pages, like [this one](https://leekduck.com/events/max-finale-promo-code/).

The code isn't in the event title, there doesn't seem to be any markup around the actual instances of the promo codes, and the event ID felt pretty unreliable as a place to get the code from. With those things in mind, I figured the most 'stable' way would to be checking the page for a link to the store redemption page, and pull the code out of the GET parameter. It adds an array of any it finds as `promocodes` in the `extraData` property.

I don't know if LeekDuck is going to keep reporting promo codes like this in the future, but it sure would be nice!

Cheers