### PR TITLE
Add support for shadow raid scraping

### DIFF
--- a/pages/raids.js
+++ b/pages/raids.js
@@ -3,102 +3,101 @@ const jsd = require('jsdom');
 const { JSDOM } = jsd;
 const https = require('https');
 
-function get()
-{
+function get() {
     return new Promise(resolve => {
         JSDOM.fromURL("https://leekduck.com/boss/", {
         })
-        .then((dom) => {
+            .then((dom) => {
 
-            const raidBosses = dom.window.document.querySelector('.raid-bosses');
-            const tiers = raidBosses.querySelectorAll('.tier');
-            let bosses = [];
+                let bosses = [];
+                const raidBosses = dom.window.document.querySelectorAll('.raid-bosses, .shadow-raid-bosses');
 
-            tiers.forEach(tierDiv => {
-                const tierHeader = tierDiv.querySelector('h2.header');
-                const currentTier = tierHeader ? tierHeader.textContent.trim() : "";
+                raidBosses.forEach(raidBossContainer => {
+                    const tiers = raidBossContainer.querySelectorAll('.tier');
 
-                const cards = tierDiv.querySelectorAll('.grid .card');
-                cards.forEach(card => {
-                    let boss = {
-                        name: "",
-                        tier: currentTier,
-                        canBeShiny: false,
-                        types: [],
-                        combatPower: {
-                            normal: { min: -1, max: -1 },
-                            boosted: { min: -1, max: -1 }
-                        },
-                        boostedWeather: [],
-                        image: ""
-                    };
+                    tiers.forEach(tierDiv => {
+                        const tierHeader = tierDiv.querySelector('h2.header');
+                        const currentTier = tierHeader ? tierHeader.textContent.trim() : "";
 
-                    // Name
-                    boss.name = card.querySelector('.identity .name')?.textContent.trim() || "";
+                        const cards = tierDiv.querySelectorAll('.grid .card');
+                        cards.forEach(card => {
+                            let boss = {
+                                name: "",
+                                tier: currentTier,
+                                canBeShiny: false,
+                                types: [],
+                                combatPower: {
+                                    normal: { min: -1, max: -1 },
+                                    boosted: { min: -1, max: -1 }
+                                },
+                                boostedWeather: [],
+                                image: ""
+                            };
 
-                    // Image
-                    boss.image = card.querySelector('.boss-img img')?.src || "";
+                            // Name
+                            boss.name = card.querySelector('.identity .name')?.textContent.trim() || "";
 
-                    // Shiny
-                    boss.canBeShiny = !!card.querySelector('.boss-img .shiny-icon');
+                            // Image
+                            boss.image = card.querySelector('.boss-img img')?.src || "";
 
-                    // Types
-                    card.querySelectorAll('.boss-type .type img').forEach(img => {
-                        boss.types.push({
-                            name: img.getAttribute('title')?.toLowerCase() || "",
-                            image: img.src
+                            // Shiny
+                            boss.canBeShiny = !!card.querySelector('.boss-img .shiny-icon');
+
+                            // Types
+                            card.querySelectorAll('.boss-type .type img').forEach(img => {
+                                boss.types.push({
+                                    name: img.getAttribute('title')?.toLowerCase() || "",
+                                    image: img.src
+                                });
+                            });
+
+                            // Combat Power (normal)
+                            let cpText = card.querySelector('.cp-range')?.textContent.replace('CP', '').trim() || "";
+                            let [cpMin, cpMax] = cpText.split('-').map(s => parseInt(s.trim()));
+                            boss.combatPower.normal.min = cpMin || -1;
+                            boss.combatPower.normal.max = cpMax || -1;
+
+                            // Combat Power (boosted)
+                            let boostedText = card.querySelector('.boosted-cp-row .boosted-cp')?.textContent.replace('CP', '').trim() || "";
+                            let [boostMin, boostMax] = boostedText.split('-').map(s => parseInt(s.trim()));
+                            boss.combatPower.boosted.min = boostMin || -1;
+                            boss.combatPower.boosted.max = boostMax || -1;
+
+                            // Boosted Weather
+                            card.querySelectorAll('.weather-boosted .boss-weather .weather-pill img').forEach(img => {
+                                boss.boostedWeather.push({
+                                    name: img.getAttribute('alt')?.toLowerCase() || "",
+                                    image: img.src
+                                });
+                            });
+
+                            bosses.push(boss);
                         });
                     });
 
-                    // Combat Power (normal)
-                    let cpText = card.querySelector('.cp-range')?.textContent.replace('CP', '').trim() || "";
-                    let [cpMin, cpMax] = cpText.split('-').map(s => parseInt(s.trim()));
-                    boss.combatPower.normal.min = cpMin || -1;
-                    boss.combatPower.normal.max = cpMax || -1;
-
-                    // Combat Power (boosted)
-                    let boostedText = card.querySelector('.boosted-cp-row .boosted-cp')?.textContent.replace('CP', '').trim() || "";
-                    let [boostMin, boostMax] = boostedText.split('-').map(s => parseInt(s.trim()));
-                    boss.combatPower.boosted.min = boostMin || -1;
-                    boss.combatPower.boosted.max = boostMax || -1;
-
-                    // Boosted Weather
-                    card.querySelectorAll('.weather-boosted .boss-weather .weather-pill img').forEach(img => {
-                        boss.boostedWeather.push({
-                            name: img.getAttribute('alt')?.toLowerCase() || "",
-                            image: img.src
-                        });
+                    fs.writeFile('files/raids.json', JSON.stringify(bosses, null, 4), err => {
+                        if (err) {
+                            console.error(err);
+                            return;
+                        }
                     });
-
-                    bosses.push(boss);
+                    fs.writeFile('files/raids.min.json', JSON.stringify(bosses), err => {
+                        if (err) {
+                            console.error(err);
+                            return;
+                        }
+                    });
                 });
-            });
-
-            fs.writeFile('files/raids.json', JSON.stringify(bosses, null, 4), err => {
-                if (err) {
-                    console.error(err);
-                    return;
-                }
-            });
-            fs.writeFile('files/raids.min.json', JSON.stringify(bosses), err => {
-                if (err) {
-                    console.error(err);
-                    return;
-                }
-            });
-        }).catch(_err =>
-            {
+            }).catch(_err => {
                 console.log(_err);
-                https.get("https://raw.githubusercontent.com/bigfoott/ScrapedDuck/data/raids.min.json", (res) =>
-                {
+                https.get("https://raw.githubusercontent.com/bigfoott/ScrapedDuck/data/raids.min.json", (res) => {
                     let body = "";
                     res.on("data", (chunk) => { body += chunk; });
-                
+
                     res.on("end", () => {
-                        try
-                        {
+                        try {
                             let json = JSON.parse(body);
-    
+
                             fs.writeFile('files/raids.json', JSON.stringify(json, null, 4), err => {
                                 if (err) {
                                     console.error(err);
@@ -112,12 +111,11 @@ function get()
                                 }
                             });
                         }
-                        catch (error)
-                        {
+                        catch (error) {
                             console.error(error.message);
                         };
                     });
-                
+
                 }).on("error", (error) => {
                     console.error(error.message);
                 });


### PR DESCRIPTION
Hey Anthony,

I've tweaked the `raids.js` scraper to handle shadow raids as well, now that the data is available on Leek Duck (Thanks to @Anna-28 for bringing it to my notice 😄).

Shadow raids are listed under a separate element `.shadow-raid-bosses`, but the element's inner structure is the same as the `raid-bosses` element that stores information about the other raid bosses. This allows the existing code to be reused with minimal changes to support shadow raids.

Let me know if any modifications are required. 😁