### PR TITLE
Fix egg scraper to handle updated HTML structure

### DIFF
--- a/pages/eggs.js
+++ b/pages/eggs.js
@@ -15,6 +15,8 @@ function get()
             var eggs = [];
             var currentType = "";
             var currentAdventureSync = false;
+            var currentGiftExchange = false;
+            
             content.forEach(c =>
             {
                 if (c.tagName == "H2")
@@ -24,9 +26,9 @@ function get()
                     currentGiftExchange = currentType.includes("(From Route Gift)");
                     currentType = currentType.split(" Eggs")[0];
                 }
-                else if (c.className == "egg-list-flex")
+                else if (c.className == "egg-grid")
                 {
-                    c.querySelectorAll(".egg-list-item").forEach(e =>
+                    c.querySelectorAll(".pokemon-card").forEach(e =>
                     {
                         var pokemon = {
                             name: "",
@@ -42,17 +44,25 @@ function get()
                             isGiftExchange: false
                         };
 
-                        pokemon.name = e.querySelector(":scope > .hatch-pkmn").innerHTML;
+                        pokemon.name = e.querySelector(".name").innerHTML;
                         pokemon.eggType = currentType;
                         pokemon.isAdventureSync = currentAdventureSync;
-                        pokemon.image = e.querySelector(":scope > .egg-list-img > img").src;
-                        pokemon.canBeShiny = e.querySelector(":scope > .shiny-icon") != null;
-                        pokemon.isRegional = e.querySelector(":scope > .regional-icon") != null;
+                        pokemon.image = e.querySelector(".icon img").src;
+                        pokemon.canBeShiny = e.querySelector(".shiny-icon") != null;
+                        pokemon.isRegional = e.querySelector(".regional-icon") != null;
                         pokemon.isGiftExchange = currentGiftExchange;
 
-                        var combatPower = e.querySelector(":scope > .font-size-smaller").innerHTML.split('</span>')[1];
-                        pokemon.combatPower.min = parseInt(combatPower.split(' - ')[0]);
-                        pokemon.combatPower.max = parseInt(combatPower.split(' - ')[1]);
+                        var cpText = e.querySelector(".cp-range").innerHTML;
+                        var cpValue = cpText.replace('<span class="label">CP </span>', '').trim();
+                        
+                        // Logic to handle single CP value if no range is provided 
+                        if (cpValue.includes(' - ')) {
+                            pokemon.combatPower.min = parseInt(cpValue.split(' - ')[0]);
+                            pokemon.combatPower.max = parseInt(cpValue.split(' - ')[1]);
+                        } else {
+                            pokemon.combatPower.min = parseInt(cpValue);
+                            pokemon.combatPower.max = parseInt(cpValue);
+                        }
 
                         eggs.push(pokemon);
                     });

--- a/pages/eggs.js
+++ b/pages/eggs.js
@@ -126,6 +126,5 @@ function get()
             });
     })
 }
-get();
 
 module.exports = { get }

--- a/pages/eggs.js
+++ b/pages/eggs.js
@@ -41,13 +41,14 @@ function get()
                                 max: -1
                             },
                             isRegional: false,
-                            isGiftExchange: false
+                            isGiftExchange: false,
+                            rarity: 0
                         };
 
-                        pokemon.name = e.querySelector(".name").innerHTML;
+                        pokemon.name = e.querySelector(".name").innerHTML || "";
                         pokemon.eggType = currentType;
                         pokemon.isAdventureSync = currentAdventureSync;
-                        pokemon.image = e.querySelector(".icon img").src;
+                        pokemon.image = e.querySelector(".icon img").src || "";
                         pokemon.canBeShiny = e.querySelector(".shiny-icon") != null;
                         pokemon.isRegional = e.querySelector(".regional-icon") != null;
                         pokemon.isGiftExchange = currentGiftExchange;
@@ -62,6 +63,12 @@ function get()
                         } else {
                             pokemon.combatPower.min = parseInt(cpValue);
                             pokemon.combatPower.max = parseInt(cpValue);
+                        }
+
+                        var rarityDiv = e.querySelector(".rarity");
+                        if (rarityDiv) {
+                            var miniEggs = rarityDiv.querySelectorAll("svg.mini-egg");
+                            pokemon.rarity = miniEggs.length;
                         }
 
                         eggs.push(pokemon);
@@ -119,5 +126,6 @@ function get()
             });
     })
 }
+get();
 
 module.exports = { get }


### PR DESCRIPTION
Hey Anthony, back with another PR that fixes the eggs endpoint issue mentioned in #28 .

I've updated the `eggs.js` scraper to handle the updated HTML structure.

**Summary of Changes:**
- Updated container selector from `.egg-list-flex` to `.egg-grid`.
- Updated item selector from `.egg-list-item` to `.pokemon-card`.
- Updated certain element selectors to match current HTML structure.
- Added missing declaration for currentGiftExchange variable (from #25) and improved CP value parsing logic to handle both ranges and single values.

Let me know if any changes are required. 😁